### PR TITLE
fix: remove fatal clearance to message from QQWebhook

### DIFF
--- a/pkg/platform/sources/qqofficial.py
+++ b/pkg/platform/sources/qqofficial.py
@@ -47,7 +47,7 @@ class QQOfficialMessageConverter(adapter.MessageConverter):
             yiri_msg_list.append(
                 platform_message.Image(base64=base64_url)
             )
-        message = ''
+            
         yiri_msg_list.append(platform_message.Plain(text=message))
         chain = platform_message.MessageChain(yiri_msg_list)
         return chain


### PR DESCRIPTION
## 概述

如 Issues #1025 所描述的，在`pkg/platform/sources/qqofficial.py`中`QQOfficialMessageConverter`类的`target2yiri`方法中，对`message`进行了清除操作，导致后续解析出了空的`Plain`。

```python
    @staticmethod
    async def target2yiri(message:str,message_id:str,pic_url:str,content_type):
        yiri_msg_list = []
        yiri_msg_list.append(
            platform_message.Source(id=message_id,time=datetime.datetime.now())
        )
        if pic_url is not None:
            base64_url = await image.get_qq_official_image_base64(pic_url=pic_url,content_type=content_type)
            yiri_msg_list.append(
                platform_message.Image(base64=base64_url)
            )
        message = ''
        yiri_msg_list.append(platform_message.Plain(text=message))
        chain = platform_message.MessageChain(yiri_msg_list)
        return chain
```

## 检查清单

### PR 作者完成

*请在方括号间写`x`以打勾

- [x] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？
- [x] 与项目所有者沟通过了吗？
- [x] 我确定已自行测试所作的更改，确保功能符合预期。

### 项目所有者完成

- [ ] 相关 issues 链接了吗？
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？
- [ ] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [ ] 文档编写了吗？