### PR TITLE
添加微信消息类型 49（聊天记录）的支持，支持处理聊天记录类型的微信消息。

### DIFF
--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -89,6 +89,7 @@ class GewechatMessageConverter(adapter.MessageConverter):
                     app_id=self.config["app_id"],
                     xml_content=image_xml,
                     token=self.config["token"],
+                    data_dir=self.config.get("data_dir", "/root/docker/gewechat/data/download"),
                     image_type=2
                 )
 

--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -87,7 +87,9 @@ class GewechatMessageConverter(adapter.MessageConverter):
                 base64_str, image_format = await image.get_gewechat_image_base64(
                     gewechat_url=self.config["gewechat_url"],
                     app_id=self.config["app_id"],
-                    xml_content=image_xml
+                    xml_content=image_xml,
+                    token=self.config["token"],
+                    image_type=2
                 )
 
                 return platform_message.MessageChain([

--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -212,7 +212,8 @@ class GeWeChatAdapter(adapter.MessagePlatformAdapter):
 
         self.quart_app = quart.Quart(__name__)
 
-
+        self.message_converter = GewechatMessageConverter(config)
+        self.event_converter = GewechatEventConverter(config)
 
         @self.quart_app.route('/gewechat/callback', methods=['POST'])
         async def gewechat_callback():

--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -160,7 +160,9 @@ class GewechatEventConverter(adapter.EventConverter):
 
 
 class GeWeChatAdapter(adapter.MessagePlatformAdapter):
-    
+
+    name: str = "gewechat"  # 定义适配器名称
+
     bot: gewechat_client.GewechatClient
     quart_app: quart.Quart
 

--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -28,7 +28,10 @@ from ...utils import image
 
 
 class GewechatMessageConverter(adapter.MessageConverter):
-    
+
+    def __init__(self, config: dict):
+        self.config = config
+
     @staticmethod
     async def yiri2target(
         message_chain: platform_message.MessageChain
@@ -48,8 +51,8 @@ class GewechatMessageConverter(adapter.MessageConverter):
 
         return content_list
 
-    @staticmethod
     async def target2yiri(
+        self,
         message: dict,
         bot_account_id: str
     ) -> platform_message.MessageChain:
@@ -74,10 +77,29 @@ class GewechatMessageConverter(adapter.MessageConverter):
             return platform_message.MessageChain(content_list)
                     
         elif message["Data"]["MsgType"] == 3:
-            image_base64 = message["Data"]["ImgBuf"]["buffer"]
-            return platform_message.MessageChain(
-                [platform_message.Image(base64=f"data:image/jpeg;base64,{image_base64}")]
-            )
+            image_xml = message["Data"]["Content"]["string"]
+            if not image_xml:
+                return platform_message.MessageChain([
+                    platform_message.Plain(text="[图片内容为空]")
+                ])
+
+            try:
+                base64_str, image_format = await image.get_gewechat_image_base64(
+                    gewechat_url=self.config["gewechat_url"],
+                    app_id=self.config["app_id"],
+                    xml_content=image_xml
+                )
+
+                return platform_message.MessageChain([
+                    platform_message.Image(
+                        base64=f"data:image/{image_format};base64,{base64_str}"
+                    )
+                ])
+            except Exception as e:
+                print(f"处理图片消息失败: {str(e)}")
+                return platform_message.MessageChain([
+                    platform_message.Plain(text="[图片处理失败]")
+                ])
 
         elif message["Data"]["MsgType"] == 49:
             # 支持微信聊天记录的消息类型，将 XML 内容转换为 MessageChain 传递
@@ -106,19 +128,23 @@ class GewechatMessageConverter(adapter.MessageConverter):
                 )
 
 class GewechatEventConverter(adapter.EventConverter):
-    
+
+    def __init__(self, config: dict):
+        self.config = config
+        self.message_converter = GewechatMessageConverter(config)
+
     @staticmethod
     async def yiri2target(
         event: platform_events.MessageEvent
     ) -> dict:
         pass
 
-    @staticmethod
     async def target2yiri(
+        self,
         event: dict,
         bot_account_id: str
     ) -> platform_events.MessageEvent:
-        message_chain = await GewechatMessageConverter.target2yiri(copy.deepcopy(event), bot_account_id)
+        message_chain = await self.message_converter.target2yiri(copy.deepcopy(event), bot_account_id)
 
         if not message_chain:
             return None
@@ -172,8 +198,8 @@ class GeWeChatAdapter(adapter.MessagePlatformAdapter):
 
     ap: app.Application
 
-    message_converter: GewechatMessageConverter = GewechatMessageConverter()
-    event_converter: GewechatEventConverter = GewechatEventConverter()
+    message_converter: GewechatMessageConverter
+    event_converter: GewechatEventConverter
 
     listeners: typing.Dict[
         typing.Type[platform_events.Event],
@@ -185,6 +211,8 @@ class GeWeChatAdapter(adapter.MessagePlatformAdapter):
         self.ap = ap
 
         self.quart_app = quart.Quart(__name__)
+
+
 
         @self.quart_app.route('/gewechat/callback', methods=['POST'])
         async def gewechat_callback():

--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -79,6 +79,32 @@ class GewechatMessageConverter(adapter.MessageConverter):
                 [platform_message.Image(base64=f"data:image/jpeg;base64,{image_base64}")]
             )
 
+        elif message["Data"]["MsgType"] == 49:
+            # 支持微信聊天记录的消息类型，将 XML 内容转换为 MessageChain 传递
+            try:
+                # 首先确保内容是字符串
+                content = message["Data"]["Content"]["string"]
+
+                # 如果内容已经是base64编码，尝试解码
+                try:
+                    # 先将字符串编码为UTF-8字节
+                    content_bytes = content.encode('utf-8')
+                    # 然后进行base64解码
+                    decoded_content = base64.b64decode(content_bytes)
+                    return platform_message.MessageChain(
+                        [platform_message.Unknown(content=decoded_content)]
+                    )
+                except Exception as e:
+                    # 如果解码失败，直接返回原始内容
+                    return platform_message.MessageChain(
+                        [platform_message.Plain(text=content)]
+                    )
+            except Exception as e:
+                print(f"Error processing type 49 message: {str(e)}")
+                return platform_message.MessageChain(
+                    [platform_message.Plain(text="[无法解析的消息]")]
+                )
+
 class GewechatEventConverter(adapter.EventConverter):
     
     @staticmethod

--- a/pkg/platform/sources/gewechat.yaml
+++ b/pkg/platform/sources/gewechat.yaml
@@ -45,6 +45,13 @@ spec:
       type: string
       required: true
       default: ""
+    - name: data_dir
+      label:
+        en_US: Data Directory
+        zh_CN: 数据目录
+      type: string
+      required: true
+      default: "/root/docker/gewechat/data/download"
 execution:
   python:
     path: ./gewechat.py

--- a/pkg/utils/image.py
+++ b/pkg/utils/image.py
@@ -54,7 +54,7 @@ async def get_gewechat_image_base64(
             if resp_data.get("ret") != 200:
                 raise Exception(f"获取gewechat图片下载链接失败: {resp_data}")
 
-            image_url = f"{gewechat_url}{resp_data['data']['fileUrl']}"
+            image_url = f"{gewechat_url}/{resp_data['data']['fileUrl']}"
 
             # 下载图片内容
             async with session.get(image_url, headers=headers) as img_response:


### PR DESCRIPTION
微信聊天记录是 xml 数据格式，本质上也是字符串，可以按照字符串Plain类型来处理。

## 概述

实现/解决/优化的内容:  支持微信的微信聊天记录类型消息

## 检查清单

### PR 作者完成

*请在方括号间写`x`以打勾

- [ x ] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？
- [ - ] 与项目所有者沟通过了吗？
- [ x ] 我确定已自行测试所作的更改，确保功能符合预期。

### 项目所有者完成

- [ ] 相关 issues 链接了吗？
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？
- [ ] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [ ] 文档编写了吗？