### PR TITLE
让llm重载可以直接获取本地最新的llm_models.json里面的内容

### DIFF
--- a/pkg/core/app.py
+++ b/pkg/core/app.py
@@ -29,6 +29,7 @@ from ..discover import engine as discover_engine
 from ..utils import logcache, ip
 from . import taskmgr
 from . import entities as core_entities
+from .bootutils import config
 
 
 class Application:
@@ -203,6 +204,15 @@ class Application:
             case core_entities.LifecycleControlScope.PROVIDER.value:
                 self.logger.info("执行热重载 scope="+scope)
 
+                latest_llm_model_config = await config.load_json_config("data/metadata/llm-models.json", "templates/metadata/llm-models.json")
+                for model in latest_llm_model_config.data['list']:
+                    for index, local_model in enumerate(self.llm_models_meta.data['list']):
+                        if model['name'] == local_model['name']:
+                            self.llm_models_meta.data['list'][index] = model
+                            break
+                    else:
+                        self.logger.info("读取到新模型="+model['name'])
+                        self.llm_models_meta.data['list'].append(model)
                 llm_model_mgr_inst = llm_model_mgr.ModelManager(self)
                 await llm_model_mgr_inst.initialize()
                 self.model_mgr = llm_model_mgr_inst

--- a/pkg/core/app.py
+++ b/pkg/core/app.py
@@ -205,14 +205,7 @@ class Application:
                 self.logger.info("执行热重载 scope="+scope)
 
                 latest_llm_model_config = await config.load_json_config("data/metadata/llm-models.json", "templates/metadata/llm-models.json")
-                for model in latest_llm_model_config.data['list']:
-                    for index, local_model in enumerate(self.llm_models_meta.data['list']):
-                        if model['name'] == local_model['name']:
-                            self.llm_models_meta.data['list'][index] = model
-                            break
-                    else:
-                        self.logger.info("读取到新模型="+model['name'])
-                        self.llm_models_meta.data['list'].append(model)
+                self.llm_models_meta = latest_llm_model_config
                 llm_model_mgr_inst = llm_model_mgr.ModelManager(self)
                 await llm_model_mgr_inst.initialize()
                 self.model_mgr = llm_model_mgr_inst


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 
让llm重载可以直接获取本地最新的llm_models.json里面的内容

## 检查清单

### PR 作者完成

*请在方括号间写`x`以打勾

- [x] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？
- [ ] 与项目所有者沟通过了吗？
- [x] 我确定已自行测试所作的更改，确保功能符合预期。

### 项目所有者完成

- [ ] 相关 issues 链接了吗？
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？
- [ ] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [ ] 文档编写了吗？