### PR TITLE
将微信消息时间戳传递给 dify，便于 dify 通过消息时间戳来做业务逻辑。

### DIFF
--- a/libs/dify_service_api/v1/client.py
+++ b/libs/dify_service_api/v1/client.py
@@ -78,6 +78,7 @@ class AsyncDifyServiceClient:
             trust_env=True,
             timeout=timeout,
         ) as client:
+            print(f"inputs: {inputs}")
 
             async with client.stream(
                 "POST",

--- a/libs/dify_service_api/v1/client.py
+++ b/libs/dify_service_api/v1/client.py
@@ -78,7 +78,6 @@ class AsyncDifyServiceClient:
             trust_env=True,
             timeout=timeout,
         ) as client:
-            print(f"inputs: {inputs}")
 
             async with client.stream(
                 "POST",

--- a/pkg/platform/sources/dingtalk.py
+++ b/pkg/platform/sources/dingtalk.py
@@ -77,7 +77,7 @@ class DingTalkEventConverter(adapter.EventConverter):
                     remark=""
                 ),
                 message_chain = message_chain,
-                time = datetime.datetime.now(),
+                time = event.incoming_message.create_at,
                 source_platform_object=event,
             )
         elif event.conversation == 'GroupMessage':
@@ -95,7 +95,7 @@ class DingTalkEventConverter(adapter.EventConverter):
                 last_speak_timestamp=0,
                 mute_time_remaining=0
             )
-            time = datetime.datetime.now(),
+            time = event.incoming_message.create_at
             return platform_events.GroupMessage(
                 sender =sender,
                 message_chain = message_chain,

--- a/pkg/platform/sources/qqofficial.py
+++ b/pkg/platform/sources/qqofficial.py
@@ -74,7 +74,11 @@ class QQOfficialEventConverter(adapter.EventConverter):
                 remark = "",
             )
             return platform_events.FriendMessage(
-                sender = friend,message_chain = yiri_chain,time = event.timestamp,
+                sender = friend,message_chain = yiri_chain,time = int(
+                    datetime.datetime.strptime(
+                        event.timestamp, "%Y-%m-%dT%H:%M:%S%z"
+                    ).timestamp()
+                ),
                 source_platform_object=event
             )
         
@@ -105,7 +109,11 @@ class QQOfficialEventConverter(adapter.EventConverter):
                 last_speak_timestamp=0,
                 mute_time_remaining=0
             )
-            time = event.timestamp
+            time = int(
+                    datetime.datetime.strptime(
+                        event.timestamp, "%Y-%m-%dT%H:%M:%S%z"
+                    ).timestamp()
+                )
             return platform_events.GroupMessage(
                 sender = sender,
                 message_chain=yiri_chain,
@@ -128,7 +136,11 @@ class QQOfficialEventConverter(adapter.EventConverter):
                 last_speak_timestamp=0,
                 mute_time_remaining=0
             )
-            time = event.timestamp,
+            time = int(
+                    datetime.datetime.strptime(
+                        event.timestamp, "%Y-%m-%dT%H:%M:%S%z"
+                    ).timestamp()
+                ),
             return platform_events.GroupMessage(
                 sender  =sender,
                 message_chain = yiri_chain,

--- a/pkg/platform/types/events.py
+++ b/pkg/platform/types/events.py
@@ -57,7 +57,7 @@ class MessageEvent(Event):
     message_chain: platform_message.MessageChain
     """消息内容。"""
 
-    time: float
+    time: float | None = None
     """消息发送时间戳。"""
 
     source_platform_object: typing.Optional[typing.Any] = None

--- a/pkg/platform/types/events.py
+++ b/pkg/platform/types/events.py
@@ -57,6 +57,9 @@ class MessageEvent(Event):
     message_chain: platform_message.MessageChain
     """消息内容。"""
 
+    time: float
+    """消息发送时间戳。"""
+
     source_platform_object: typing.Optional[typing.Any] = None
     """原消息平台对象。
     供消息平台适配器开发者使用，如果回复用户时需要使用原消息事件对象的信息，

--- a/pkg/provider/runners/difysvapi.py
+++ b/pkg/provider/runners/difysvapi.py
@@ -61,7 +61,7 @@ class DifyServiceAPIRunner(runner.RequestRunner):
 
     async def _preprocess_user_message(
         self, query: core_entities.Query
-    ) -> tuple[str, list[str], int | None]:
+    ) -> tuple[str, list[str]]:
         """预处理用户消息，提取纯文本，并将图片上传到 Dify 服务
 
         Returns:

--- a/pkg/provider/runners/difysvapi.py
+++ b/pkg/provider/runners/difysvapi.py
@@ -5,6 +5,7 @@ import json
 import uuid
 import re
 import base64
+import datetime
 
 import aiohttp
 
@@ -232,15 +233,7 @@ class DifyServiceAPIRunner(runner.RequestRunner):
         plain_text, image_ids = await self._preprocess_user_message(query)
 
         # 尝试获取 CreateTime
-        create_time = 0
-        try:
-            timestamp = query.message_event.source_platform_object.get('Data', {}).get('CreateTime')
-            # 确保 timestamp 是整数类型
-            if isinstance(timestamp, (int, float)):
-                create_time = int(timestamp)
-        except AttributeError:
-            # 如果获取过程中发生属性错误，保持 create_time 为 None
-            pass
+        create_time = int(query.message_event.time) if query.message_event.time else int(datetime.datetime.now().timestamp())
 
         files = [
             {

--- a/pkg/provider/runners/difysvapi.py
+++ b/pkg/provider/runners/difysvapi.py
@@ -256,9 +256,9 @@ class DifyServiceAPIRunner(runner.RequestRunner):
         async for chunk in self.dify_client.workflow_run(
             inputs={
                 "langbot_user_message_text": plain_text,
-                "langbot_session_id": f"{query.session.launcher_type.value}_{query.session.launcher_id}_{create_time}",
+                "langbot_session_id": f"{query.session.launcher_type.value}_{query.session.launcher_id}",
                 "langbot_conversation_id": cov_id,
-                "langbot_msg_create_time": f"ctime_{create_time}",
+                "langbot_msg_create_time": create_time,
             },
             user=f"{query.session.launcher_type.value}_{query.session.launcher_id}",
             files=files,

--- a/pkg/provider/runners/difysvapi.py
+++ b/pkg/provider/runners/difysvapi.py
@@ -258,7 +258,7 @@ class DifyServiceAPIRunner(runner.RequestRunner):
                 "langbot_user_message_text": plain_text,
                 "langbot_session_id": f"{query.session.launcher_type.value}_{query.session.launcher_id}_{create_time}",
                 "langbot_conversation_id": cov_id,
-                "langbot_msg_create_time": create_time,
+                "langbot_msg_create_time": f"ctime_{create_time}",
             },
             user=f"{query.session.launcher_type.value}_{query.session.launcher_id}",
             files=files,

--- a/pkg/provider/runners/difysvapi.py
+++ b/pkg/provider/runners/difysvapi.py
@@ -229,7 +229,7 @@ class DifyServiceAPIRunner(runner.RequestRunner):
 
         cov_id = query.session.using_conversation.uuid
 
-        plain_text, image_ids, timestamp = await self._preprocess_user_message(query)
+        plain_text, image_ids = await self._preprocess_user_message(query)
 
         # 尝试获取 CreateTime
         create_time = 0


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 
给dify workflow传递langbot_msg_create_time参数，gewechat的消息时间，方便dify workflow里通过判断微信消息时间戳来做对应的逻辑。

## 检查清单

### PR 作者完成

*请在方括号间写`x`以打勾

- [ x ] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？
- [ - ] 与项目所有者沟通过了吗？
- [ x ] 我确定已自行测试所作的更改，确保功能符合预期。

### 项目所有者完成

- [ ] 相关 issues 链接了吗？
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？
- [ ] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [ ] 文档编写了吗？