### PR TITLE
typo: fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <a href="https://trendshift.io/repositories/12901" target="_blank"><img src="https://trendshift.io/api/badge/repositories/12901" alt="RockChinQ%2FLangBot | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 <a href="https://docs.langbot.app">项目主页</a> ｜
-<a href="https://docs.langbot.app/insight/intro.htmll">功能介绍</a> ｜
+<a href="https://docs.langbot.app/insight/intro.html">功能介绍</a> ｜
 <a href="https://docs.langbot.app/insight/guide.html">部署文档</a> ｜
 <a href="https://docs.langbot.app/usage/faq.html">常见问题</a> ｜
 <a href="https://docs.langbot.app/plugin/plugin-intro.html">插件介绍</a> ｜

--- a/README_EN.md
+++ b/README_EN.md
@@ -8,7 +8,7 @@
 <a href="https://trendshift.io/repositories/12901" target="_blank"><img src="https://trendshift.io/api/badge/repositories/12901" alt="RockChinQ%2FLangBot | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 <a href="https://docs.langbot.app">Home</a> ｜
-<a href="https://docs.langbot.app/insight/intro.htmll">Features</a> ｜
+<a href="https://docs.langbot.app/insight/intro.html">Features</a> ｜
 <a href="https://docs.langbot.app/insight/guide.html">Deployment</a> ｜
 <a href="https://docs.langbot.app/usage/faq.html">FAQ</a> ｜
 <a href="https://docs.langbot.app/plugin/plugin-intro.html">Plugin</a> ｜

--- a/README_JP.md
+++ b/README_JP.md
@@ -8,7 +8,7 @@
 <a href="https://trendshift.io/repositories/12901" target="_blank"><img src="https://trendshift.io/api/badge/repositories/12901" alt="RockChinQ%2FLangBot | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 <a href="https://docs.langbot.app">ホーム</a> ｜
-<a href="https://docs.langbot.app/insight/intro.htmll">機能</a> ｜
+<a href="https://docs.langbot.app/insight/intro.html">機能</a> ｜
 <a href="https://docs.langbot.app/insight/guide.html">デプロイ</a> ｜
 <a href="https://docs.langbot.app/usage/faq.html">FAQ</a> ｜
 <a href="https://docs.langbot.app/plugin/plugin-intro.html">プラグイン</a> ｜


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 
fix typo in README
<a href="https://docs.langbot.app/insight/intro.htmll">功能介绍</a>
=>
<a href="https://docs.langbot.app/insight/intro.html">功能介绍</a>
## 检查清单

### PR 作者完成

*请在方括号间写`x`以打勾

- [ x ] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？
- [ ] 与项目所有者沟通过了吗？
- [ x ] 我确定已自行测试所作的更改，确保功能符合预期。

### 项目所有者完成

- [ ] 相关 issues 链接了吗？
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？
- [ ] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [ x ] 文档编写了吗？