### PR TITLE
当机器人群名称改名后群聊单独at机器人时候替换@信息为空

### DIFF
--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -63,12 +63,11 @@ class GewechatMessageConverter(adapter.MessageConverter):
     ) -> platform_message.MessageChain:
 
 
-        # print(message)
 
         if message["Data"]["MsgType"] == 1:
             # 检查消息开头，如果有 wxid_sbitaz0mt65n22:\n 则删掉
             regex = re.compile(r"^wxid_.*:")
-            print(message)
+            # print(message)
 
             line_split = message["Data"]["Content"]["string"].split("\n")
 
@@ -82,10 +81,9 @@ class GewechatMessageConverter(adapter.MessageConverter):
             if at_string in message["Data"]["Content"]["string"]:
                 content_list.append(platform_message.At(target=bot_account_id))
                 content_list.append(platform_message.Plain(message["Data"]["Content"]["string"].replace(at_string, '', 1)))
-            # 更优雅的替换@机器人，仅仅限于单独AT的情况
+            # 更优雅的替换改名后@机器人，仅仅限于单独AT的情况
             elif '在群聊中@了你' in message["Data"]["PushContent"]:
                 content_list.append(platform_message.At(target=bot_account_id))
-                print(re.sub(pattern, '', message["Data"]["Content"]["string"]))
                 content_list.append(platform_message.Plain(re.sub(pattern, '', message["Data"]["Content"]["string"])))
             else:
                 content_list = [platform_message.Plain(message["Data"]["Content"]["string"])]

--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -68,31 +68,24 @@ class GewechatMessageConverter(adapter.MessageConverter):
         if message["Data"]["MsgType"] == 1:
             # 检查消息开头，如果有 wxid_sbitaz0mt65n22:\n 则删掉
             regex = re.compile(r"^wxid_.*:")
-            # print(message)
+            print(message)
 
             line_split = message["Data"]["Content"]["string"].split("\n")
 
             if len(line_split) > 0 and regex.match(line_split[0]):
                 message["Data"]["Content"]["string"] = "\n".join(line_split[1:])
-            # 获取机器人在群内信息
-            # bot_room_datas = bot.get_chatroom_member_detail(
-            #     self.config["app_id"],
-            #     message['Data']['FromUserName']['string'],
-            #     [message['Data']["ToUserName"]['string']]
-            # )['data']
-            # print(bot_room_datas)
-            # # 拿到机器人在群内名称
-            # at_string = ''
-            # for bot_data in bot_room_datas:
-            #     bot_room_name = bot_data['nickName']
-            #     at_string += f"@{bot_room_name}"
+
             # 正则表达式模式，匹配'@'后跟任意数量的非空白字符
             pattern = r'@\S+'
-            # at_string = f"@{bot_account_id}"
+            at_string = f"@{bot_account_id}"
             content_list = []
-            if '@' in message["Data"]["Content"]["string"]:
+            if at_string in message["Data"]["Content"]["string"]:
                 content_list.append(platform_message.At(target=bot_account_id))
-                # print(re.sub(pattern, '', message["Data"]["Content"]["string"]))
+                content_list.append(platform_message.Plain(message["Data"]["Content"]["string"].replace(at_string, '', 1)))
+            # 更优雅的替换@机器人，仅仅限于单独AT的情况
+            elif '在群聊中@了你' in message["Data"]["PushContent"]:
+                content_list.append(platform_message.At(target=bot_account_id))
+                print(re.sub(pattern, '', message["Data"]["Content"]["string"]))
                 content_list.append(platform_message.Plain(re.sub(pattern, '', message["Data"]["Content"]["string"])))
             else:
                 content_list = [platform_message.Plain(message["Data"]["Content"]["string"])]

--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -62,20 +62,38 @@ class GewechatMessageConverter(adapter.MessageConverter):
         bot_account_id: str
     ) -> platform_message.MessageChain:
 
+
+        # print(message)
+
         if message["Data"]["MsgType"] == 1:
             # 检查消息开头，如果有 wxid_sbitaz0mt65n22:\n 则删掉
             regex = re.compile(r"^wxid_.*:")
+            # print(message)
 
             line_split = message["Data"]["Content"]["string"].split("\n")
 
             if len(line_split) > 0 and regex.match(line_split[0]):
                 message["Data"]["Content"]["string"] = "\n".join(line_split[1:])
-
-            at_string = f'@{bot_account_id}'
+            # 获取机器人在群内信息
+            # bot_room_datas = bot.get_chatroom_member_detail(
+            #     self.config["app_id"],
+            #     message['Data']['FromUserName']['string'],
+            #     [message['Data']["ToUserName"]['string']]
+            # )['data']
+            # print(bot_room_datas)
+            # # 拿到机器人在群内名称
+            # at_string = ''
+            # for bot_data in bot_room_datas:
+            #     bot_room_name = bot_data['nickName']
+            #     at_string += f"@{bot_room_name}"
+            # 正则表达式模式，匹配'@'后跟任意数量的非空白字符
+            pattern = r'@\S+'
+            # at_string = f"@{bot_account_id}"
             content_list = []
-            if at_string in message["Data"]["Content"]["string"]:
+            if '@' in message["Data"]["Content"]["string"]:
                 content_list.append(platform_message.At(target=bot_account_id))
-                content_list.append(platform_message.Plain(message["Data"]["Content"]["string"].replace(at_string, "", 1)))
+                # print(re.sub(pattern, '', message["Data"]["Content"]["string"]))
+                content_list.append(platform_message.Plain(re.sub(pattern, '', message["Data"]["Content"]["string"])))
             else:
                 content_list = [platform_message.Plain(message["Data"]["Content"]["string"])]
 


### PR DESCRIPTION
## 概述

当机器人群名称改名后群聊单独at机器人时候替换@信息为空。暂时解决#1192

## 检查清单

### PR 作者完成

*请在方括号间写`x`以打勾

- [x] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？
- [x] 与项目所有者沟通过了吗？
- [x] 我确定已自行测试所作的更改，确保功能符合预期。

### 项目所有者完成

- [x] 相关 issues 链接了吗？
- [x] 配置项写好了吗？迁移写好了吗？生效了吗？
- [x] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [ ] 文档编写了吗？