### PR TITLE
fix: Fix SSL certificate verification error during GitHub plugin installation

### DIFF
--- a/pkg/core/bootutils/deps.py
+++ b/pkg/core/bootutils/deps.py
@@ -33,6 +33,7 @@ required_deps = {
     "dingtalk_stream": "dingtalk_stream",
     "dashscope": "dashscope",
     "telegram": "python-telegram-bot",
+    "certifi": "certifi",
 }
 
 

--- a/pkg/plugin/installers/github.py
+++ b/pkg/plugin/installers/github.py
@@ -4,6 +4,8 @@ import re
 import os
 import shutil
 import zipfile
+import ssl
+import certifi
 
 import aiohttp
 import aiofiles
@@ -21,44 +23,39 @@ class GitHubRepoInstaller(installer.PluginInstaller):
 
     def get_github_plugin_repo_label(self, repo_url: str) -> list[str]:
         """获取username, repo"""
-
-        # 提取 username/repo , 正则表达式
         repo = re.findall(
             r"(?:https?://github\.com/|git@github\.com:)([^/]+/[^/]+?)(?:\.git|/|$)",
             repo_url,
         )
-
-        if len(repo) > 0:  # github
+        if len(repo) > 0:
             return repo[0].split("/")
         else:
             return None
-    
+
     async def download_plugin_source_code(self, repo_url: str, target_path: str, task_context: taskmgr.TaskContext = taskmgr.TaskContext.placeholder()) -> str:
         """下载插件源码（全异步）"""
-        
-        # 提取 username/repo , 正则表达式
         repo = self.get_github_plugin_repo_label(repo_url)
-
-        target_path += repo[1]
-
         if repo is None:
             raise errors.PluginInstallerError('仅支持GitHub仓库地址')
         
+        target_path += repo[1]
         self.ap.logger.debug("正在下载源码...")
         task_context.trace("下载源码...", "download-plugin-source-code")
         
         zipball_url = f"https://api.github.com/repos/{'/'.join(repo)}/zipball/HEAD"
-
         zip_resp: bytes = None
+        
+        # 创建自定义SSL上下文，使用certifi提供的根证书
+        ssl_context = ssl.create_default_context(cafile=certifi.where())
 
         async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.get(
                 url=zipball_url,
-                timeout=aiohttp.ClientTimeout(total=300)
+                timeout=aiohttp.ClientTimeout(total=300),
+                ssl=ssl_context  # 使用自定义SSL上下文来验证证书
             ) as resp:
                 if resp.status != 200:
-                    raise errors.PluginInstallerError(f"下载源码失败: {resp.text}")
-                
+                    raise errors.PluginInstallerError(f"下载源码失败: {await resp.text()}")
                 zip_resp = await resp.read()
         
         if await aiofiles_os.path.exists("temp/" + target_path):
@@ -80,15 +77,11 @@ class GitHubRepoInstaller(installer.PluginInstaller):
         await aiofiles_os.remove("temp/" + target_path + "/source.zip")
 
         import glob
-
         unzip_dir = glob.glob("temp/" + target_path + "/*")[0]
-
         await aioshutil.copytree(unzip_dir, target_path + "/")
-
         await aioshutil.rmtree(unzip_dir)
         
         self.ap.logger.debug("源码下载完成。")
-
         return repo[1]
 
     async def install_requirements(self, path: str):
@@ -100,20 +93,14 @@ class GitHubRepoInstaller(installer.PluginInstaller):
         plugin_source: str,
         task_context: taskmgr.TaskContext = taskmgr.TaskContext.placeholder(),
     ):
-        """安装插件
-        """
+        """安装插件"""
         task_context.trace("下载插件源码...", "install-plugin")
-
         repo_label = await self.download_plugin_source_code(plugin_source, "plugins/", task_context)
-
         task_context.trace("安装插件依赖...", "install-plugin")
-
         await self.install_requirements("plugins/" + repo_label)
-
         task_context.trace("完成.", "install-plugin")
-
         await self.ap.plugin_mgr.setting.record_installed_plugin_source(
-            "plugins/"+repo_label+'/', plugin_source
+            "plugins/" + repo_label + '/', plugin_source
         )
 
     async def uninstall_plugin(
@@ -121,10 +108,8 @@ class GitHubRepoInstaller(installer.PluginInstaller):
         plugin_name: str,
         task_context: taskmgr.TaskContext = taskmgr.TaskContext.placeholder(),
     ):
-        """卸载插件
-        """
+        """卸载插件"""
         plugin_container = self.ap.plugin_mgr.get_plugin_by_name(plugin_name)
-
         if plugin_container is None:
             raise errors.PluginInstallerError('插件不存在或未成功加载')
         else:
@@ -135,24 +120,18 @@ class GitHubRepoInstaller(installer.PluginInstaller):
     async def update_plugin(
         self,
         plugin_name: str,
-        plugin_source: str=None,
+        plugin_source: str = None,
         task_context: taskmgr.TaskContext = taskmgr.TaskContext.placeholder(),
     ):
-        """更新插件
-        """
+        """更新插件"""
         task_context.trace("更新插件...", "update-plugin")
-
         plugin_container = self.ap.plugin_mgr.get_plugin_by_name(plugin_name)
-
         if plugin_container is None:
             raise errors.PluginInstallerError('插件不存在或未成功加载')
         else:
             if plugin_container.plugin_source:
                 plugin_source = plugin_container.plugin_source
-
                 task_context.trace("转交安装任务.", "update-plugin")
-
                 await self.install_plugin(plugin_source, task_context)
-
             else:
                 raise errors.PluginInstallerError('插件无源码信息，无法更新')

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ gewechat-client
 dingtalk_stream
 dashscope
 python-telegram-bot
+certifi
 
 # indirect
 taskgroup==0.0.0a4


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 

### fix: 修复 GitHub 插件安装时的 SSL 证书验证失败问题

- 使用 certifi 创建自定义 SSL 上下文，确保 HTTPS 连接验证正确
- 为 aiohttp 请求添加 ssl 参数，防止因缺失根证书导致下载失败
- 修正相关错误提示，插件安装流程更稳固
- 将 `certifi` 写入了 `requirements.txt`

- Create a custom SSL context using certifi for proper HTTPS certificate verification
- Add the ssl parameter to aiohttp requests to prevent download failure due to missing root certificates
- Improve error messages and enhance the overall plugin installation process


## 检查清单

### PR 作者完成

*请在方括号间写`x`以打勾

- [x] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？
- [x] 与项目所有者沟通过了吗？
- [x] 我确定已自行测试所作的更改，确保功能符合预期。

### 项目所有者完成

- [ ] 相关 issues 链接了吗？
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？
- [ ] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [ ] 文档编写了吗？