### PR TITLE
feat(gewechat): 新增引用消息转发+@在引用中的bug修复

### DIFF
--- a/pkg/platform/sources/gewechat.py
+++ b/pkg/platform/sources/gewechat.py
@@ -124,7 +124,7 @@ class GewechatMessageConverter(adapter.MessageConverter):
     ) -> platform_message.MessageChain:
         """处理文本消息 (msg_type=1)"""
         if message and self._is_group_message(message):
-            pattern = r'@\S+'
+            pattern = r'@\S{1,20}'
             content_no_preifx = re.sub(pattern, '', content_no_preifx)
         
         return platform_message.MessageChain([platform_message.Plain(content_no_preifx)])
@@ -275,14 +275,15 @@ class GewechatMessageConverter(adapter.MessageConverter):
                 pattern = r'^@\S+'
                 user_data = re.sub(pattern, '', user_data)
                 message_list.append(platform_message.Plain(user_data))
-        # print(f"**_handler_compound_quote message_list len={len(message_list)}")
+        
         # for comp in message_list:
         #     if isinstance(comp, platform_message.Quote):
-        #         print(f"**_handler_compound_quote send_id {comp.sender_id}" )
+        #         print(f"quote_message_chain len={len(message_list)}")
+        #         print(f"quote_message_chain send_id={comp.sender_id}" )
         #         for quote_item in comp.origin:
-        #             print(f"******* _handler_compound_quote item {quote_item.type} + message: {quote_item}" )
+        #             print(f"--quote_message_component [msg_type={quote_item.type}][message={quote_item}]" )
         #     else:
-        #         print(f"_handler_compound_quote type: {comp.type} + message: {comp}")
+        #         print(f"quote_message_chain plain [msg_type={comp.type}][message={comp.text}]")
         return platform_message.MessageChain(message_list)
 
     async def _handler_compound_file(

--- a/pkg/platform/types/message.py
+++ b/pkg/platform/types/message.py
@@ -894,3 +894,11 @@ class WeChatAppMsg(MessageComponent):
     app_msg: str
     def __str__(self):
         return self.app_msg
+
+class WeChatForwardQuote(MessageComponent):
+    """转发引用消息。个人微信专用组件。"""
+    type: str = 'WeChatForwardQuote'
+    """xml数据"""
+    app_msg: str
+    def __str__(self):
+        return self.app_msg


### PR DESCRIPTION
## 概述

- 新增引用消息转发，为什么要做这个事？
  - 引用消息中有诸多要素，不好逐个定义在Quote类中。
  - 引用消息在消息链的表现是被拆分为Plain和Quote，而gewechat做reply只能按照component维度。
  - 引用消息转发定义为新的类型，WechatForwadxxx类的xml消息，用户不订阅，就不感知。可以供一些高级开发者使用。

- @ 修复
  - 被引用消息里面带有@bot时，也会触发，这个是不符合预期的。去掉这个逻辑不影响@使用。
  - @xxx 做正则剔除时，应该限制长度。

## 检查清单

### PR 作者完成

*请在方括号间写`x`以打勾

- [x] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？
- [ ] 与项目所有者沟通过了吗？
- [ ] 我确定已自行测试所作的更改，确保功能符合预期。

### 项目所有者完成

- [ ] 相关 issues 链接了吗？
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？
- [ ] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [ ] 文档编写了吗？