### PR TITLE
feat:support dify message streaming output

### DIFF
--- a/pkg/platform/botmgr.py
+++ b/pkg/platform/botmgr.py
@@ -91,11 +91,13 @@ class RuntimeBot:
                 if isinstance(e, asyncio.CancelledError):
                     self.task_context.set_current_action('Exited.')
                     return
+
+                traceback_str = traceback.format_exc()
                 self.task_context.set_current_action('Exited with error.')
                 self.task_context.log(f'平台适配器运行出错: {e}')
-                self.task_context.log(f'Traceback: {traceback.format_exc()}')
+                self.task_context.log(f'Traceback: {traceback_str}')
                 self.ap.logger.error(f'平台适配器运行出错: {e}')
-                self.ap.logger.debug(f'Traceback: {traceback.format_exc()}')
+                self.ap.logger.debug(f'Traceback: {traceback_str}')
 
         self.task_wrapper = self.ap.task_mgr.create_task(
             exception_wrapper(),

--- a/pkg/platform/sources/lark.py
+++ b/pkg/platform/sources/lark.py
@@ -332,7 +332,7 @@ class LarkAdapter(adapter.MessagePlatformAdapter):
     listeners: typing.Dict[
         typing.Type[platform_events.Event],
         typing.Callable[[platform_events.Event, adapter.MessagePlatformAdapter], None],
-    ] = {}
+    ]
 
     config: dict
     quart_app: quart.Quart
@@ -342,6 +342,7 @@ class LarkAdapter(adapter.MessagePlatformAdapter):
         self.config = config
         self.ap = ap
         self.quart_app = quart.Quart(__name__)
+        self.listeners = {}
 
         @self.quart_app.route('/lark/callback', methods=['POST'])
         async def lark_callback():

--- a/pkg/platform/sources/lark.py
+++ b/pkg/platform/sources/lark.py
@@ -9,6 +9,7 @@ import re
 import base64
 import uuid
 import json
+import time
 import datetime
 import hashlib
 from Crypto.Cipher import AES
@@ -319,6 +320,10 @@ class LarkEventConverter(adapter.EventConverter):
             )
 
 
+CARD_ID_CACHE_SIZE = 500
+CARD_ID_CACHE_MAX_LIFETIME = 20 * 60  # 20分钟
+
+
 class LarkAdapter(adapter.MessagePlatformAdapter):
     bot: lark_oapi.ws.Client
     api_client: lark_oapi.Client
@@ -338,11 +343,14 @@ class LarkAdapter(adapter.MessagePlatformAdapter):
     quart_app: quart.Quart
     ap: app.Application
 
+    message_id_to_card_id: typing.Dict[str, typing.Tuple[str, int]]
+
     def __init__(self, config: dict, ap: app.Application):
         self.config = config
         self.ap = ap
         self.quart_app = quart.Quart(__name__)
         self.listeners = {}
+        self.message_id_to_card_id = {}
 
         @self.quart_app.route('/lark/callback', methods=['POST'])
         async def lark_callback():
@@ -388,12 +396,19 @@ class LarkAdapter(adapter.MessagePlatformAdapter):
                 return {'code': 500, 'message': 'error'}
 
         async def on_message(event: lark_oapi.im.v1.P2ImMessageReceiveV1):
-            if self.config['enable-card-reply']:
+            if self.config['enable-card-reply'] and event.event.message.message_id not in self.message_id_to_card_id:
                 self.ap.logger.debug('卡片回复模式开启')
                 # 开启卡片回复模式. 这里可以实现飞书一发消息，马上创建卡片进行回复"思考中..."
                 reply_message_id = await self.create_message_card(event.event.message.message_id)
-                # message到来后需要更新卡片，所以要把reply_message_id作为message_id
-                event.event.message.message_id = reply_message_id
+                self.message_id_to_card_id[event.event.message.message_id] = (reply_message_id, time.time())
+
+                if len(self.message_id_to_card_id) > CARD_ID_CACHE_SIZE:
+                    self.message_id_to_card_id = {
+                        k: v
+                        for k, v in self.message_id_to_card_id.items()
+                        if v[1] > time.time() - CARD_ID_CACHE_MAX_LIFETIME
+                    }
+
             lb_event = await self.event_converter.target2yiri(event, self.api_client)
 
             await self.listeners[type(lb_event)](lb_event, self)
@@ -412,43 +427,38 @@ class LarkAdapter(adapter.MessagePlatformAdapter):
 
     async def send_message(self, target_type: str, target_id: str, message: platform_message.MessageChain):
         pass
-    
-    async def create_message_card(self,message_id: str) -> str:
+
+    async def create_message_card(self, message_id: str) -> str:
         """
         创建卡片消息。
-        使用卡片消息是因为普通消息更新次数有限制，而大模型流式返回结果可能很多而超过限制，而飞书卡片没有这个限制 
-        """      
-        
+        使用卡片消息是因为普通消息更新次数有限制，而大模型流式返回结果可能很多而超过限制，而飞书卡片没有这个限制
+        """
+
         # TODO 目前只支持卡片模板方式，且卡片变量一定是content，未来这块要做成可配置
         # 发消息马上就会回复显示初始化的content信息，即思考中
         content = {
-            "type": "template",
-            "data": {
-                "template_id": self.config['card_template_id'],
-                "template_variable": {
-                    "content": "思考中"
-                }
-            }
+            'type': 'template',
+            'data': {'template_id': self.config['card_template_id'], 'template_variable': {'content': 'Thinking...'}},
         }
-        request: ReplyMessageRequest = ReplyMessageRequest.builder() \
-            .message_id(message_id) \
-            .request_body(ReplyMessageRequestBody.builder()
-                .content(json.dumps(content))
-                .msg_type("interactive")
-                .build()) \
+        request: ReplyMessageRequest = (
+            ReplyMessageRequest.builder()
+            .message_id(message_id)
+            .request_body(
+                ReplyMessageRequestBody.builder().content(json.dumps(content)).msg_type('interactive').build()
+            )
             .build()
+        )
 
         # 发起请求
-        response: ReplyMessageResponse = await self.api_client.im.v1.message.areply(
-            request
-        )
+        response: ReplyMessageResponse = await self.api_client.im.v1.message.areply(request)
 
         # 处理失败返回
         if not response.success():
             raise Exception(
-                f"client.im.v1.message.reply failed, code: {response.code}, msg: {response.msg}, log_id: {response.get_log_id()}, resp: \n{json.dumps(json.loads(response.raw.content), indent=4, ensure_ascii=False)}")
+                f'client.im.v1.message.reply failed, code: {response.code}, msg: {response.msg}, log_id: {response.get_log_id()}, resp: \n{json.dumps(json.loads(response.raw.content), indent=4, ensure_ascii=False)}'
+            )
         return response.data.message_id
-    
+
     async def reply_message(
         self,
         message_source: platform_events.MessageEvent,
@@ -459,7 +469,7 @@ class LarkAdapter(adapter.MessagePlatformAdapter):
             await self.reply_card_message(message_source, message, quote_origin)
         else:
             await self.reply_normal_message(message_source, message, quote_origin)
-            
+
     async def reply_card_message(
         self,
         message_source: platform_events.MessageEvent,
@@ -469,31 +479,26 @@ class LarkAdapter(adapter.MessagePlatformAdapter):
         """
         回复消息变成更新卡片消息
         """
-        lark_message = await self.message_converter.yiri2target(
-            message, self.api_client
-        )
-        
-        try:
-            text_message = lark_message[0][0]['text']
-        except:
-            return
-        
+        lark_message = await self.message_converter.yiri2target(message, self.api_client)
+
+        text_message = ''
+        for ele in lark_message[0]:
+            if ele['tag'] == 'text':
+                text_message += ele['text']
+            elif ele['tag'] == 'md':
+                text_message += ele['text']
+
         content = {
-            "type": "template",
-            "data": {
-                "template_id": self.config['card_template_id'],
-                "template_variable": {
-                    "content": text_message
-                }
-            }
+            'type': 'template',
+            'data': {'template_id': self.config['card_template_id'], 'template_variable': {'content': text_message}},
         }
-    
-        request: PatchMessageRequest = PatchMessageRequest.builder() \
-            .message_id(message_source.message_chain.message_id) \
-            .request_body(PatchMessageRequestBody.builder()
-                .content(json.dumps(content))
-                .build()) \
+
+        request: PatchMessageRequest = (
+            PatchMessageRequest.builder()
+            .message_id(self.message_id_to_card_id[message_source.message_chain.message_id][0])
+            .request_body(PatchMessageRequestBody.builder().content(json.dumps(content)).build())
             .build()
+        )
 
         # 发起请求
         response: PatchMessageResponse = self.api_client.im.v1.message.patch(request)
@@ -501,8 +506,10 @@ class LarkAdapter(adapter.MessagePlatformAdapter):
         # 处理失败返回
         if not response.success():
             raise Exception(
-                f"client.im.v1.message.patch failed, code: {response.code}, msg: {response.msg}, log_id: {response.get_log_id()}, resp: \n{json.dumps(json.loads(response.raw.content), indent=4, ensure_ascii=False)}")
+                f'client.im.v1.message.patch failed, code: {response.code}, msg: {response.msg}, log_id: {response.get_log_id()}, resp: \n{json.dumps(json.loads(response.raw.content), indent=4, ensure_ascii=False)}'
+            )
             return
+
     async def reply_normal_message(
         self,
         message_source: platform_events.MessageEvent,

--- a/pkg/platform/sources/lark.py
+++ b/pkg/platform/sources/lark.py
@@ -564,12 +564,10 @@ class LarkAdapter(adapter.MessagePlatformAdapter):
 
         if not enable_webhook:
             try:
-                self.ap.logger.info(f'connecting to {self}')
                 await self.bot._connect()
             except lark_oapi.ws.exception.ClientException as e:
                 raise e
             except Exception as e:
-                self.ap.logger.error(f'connect error. {str(e)}')
                 await self.bot._disconnect()
                 if self.bot._auto_reconnect:
                     await self.bot._reconnect()

--- a/pkg/platform/sources/lark.yaml
+++ b/pkg/platform/sources/lark.yaml
@@ -62,6 +62,23 @@ spec:
       type: string
       required: true
       default: ""
+    - name: enable-card-reply
+      label:
+        en_US: Enable Card Reply Mode
+        zh_Hans: 启用飞书卡片回复模式
+      description:
+        en_US: If enabled, the bot will use the card of lark reply mode
+        zh_Hans: 如果启用，将使用飞书卡片方式来回复内容
+      type: boolean
+      required: true
+      default: false
+    - name: card_template_id
+      label:
+        en_US: card template id
+        zh_Hans: 卡片模板ID
+      type: string
+      required: true
+      default: "填写你的卡片template_id"
 execution:
   python:
     path: ./lark.py

--- a/pkg/provider/runners/difysvapi.py
+++ b/pkg/provider/runners/difysvapi.py
@@ -107,10 +107,12 @@ class DifyServiceAPIRunner(runner.RequestRunner):
 
         mode = 'basic'  # 标记是基础编排还是工作流编排
 
-        basic_mode_pending_chunk = ''
-        
-        batch_pending_max_size = self.pipeline_config['ai']['dify-service-api'].get('output-batch-size', 0) # 积累一定量的消息更新消息一次
-        
+        stream_output_pending_chunk = ''
+
+        batch_pending_max_size = self.pipeline_config['ai']['dify-service-api'].get(
+            'output-batch-size', 0
+        )  # 积累一定量的消息更新消息一次
+
         batch_pending_index = 0
 
         inputs = {}
@@ -128,13 +130,13 @@ class DifyServiceAPIRunner(runner.RequestRunner):
             timeout=120,
         ):
             self.ap.logger.debug('dify-chat-chunk: ' + str(chunk))
-            
+
             # 查询异常情况
             if chunk['event'] == 'error':
                 yield llm_entities.Message(
-                        role="assistant",
-                        content=f"查询异常: [{chunk['code']}]. {chunk['message']}.\n请重试，如果还报错，请用 <font color='red'>**!reset**</font> 命令重置对话再尝试。",
-                    )
+                    role='assistant',
+                    content=f"查询异常: [{chunk['code']}]. {chunk['message']}.\n请重试，如果还报错，请用 <font color='red'>**!reset**</font> 命令重置对话再尝试。",
+                )
 
             if chunk['event'] == 'workflow_started':
                 mode = 'workflow'
@@ -146,24 +148,35 @@ class DifyServiceAPIRunner(runner.RequestRunner):
                             role='assistant',
                             content=self._try_convert_thinking(chunk['data']['outputs']['answer']),
                         )
-            elif mode == 'basic':
-                if chunk['event'] == 'message':
-                    basic_mode_pending_chunk += chunk['answer']
-                    if self.pipeline_config['ai']['dify-service-api'].get('enable-streaming', False): 
+                elif chunk['event'] == 'message':
+                    stream_output_pending_chunk += chunk['answer']
+                    if self.pipeline_config['ai']['dify-service-api'].get('enable-streaming', False):
                         # 消息数超过量就输出，从而达到streaming的效果
                         batch_pending_index += 1
                         if batch_pending_index >= batch_pending_max_size:
                             yield llm_entities.Message(
-                                role="assistant",
-                                content=self._try_convert_thinking(basic_mode_pending_chunk),
+                                role='assistant',
+                                content=self._try_convert_thinking(stream_output_pending_chunk),
+                            )
+                            batch_pending_index = 0
+            elif mode == 'basic':
+                if chunk['event'] == 'message':
+                    stream_output_pending_chunk += chunk['answer']
+                    if self.pipeline_config['ai']['dify-service-api'].get('enable-streaming', False):
+                        # 消息数超过量就输出，从而达到streaming的效果
+                        batch_pending_index += 1
+                        if batch_pending_index >= batch_pending_max_size:
+                            yield llm_entities.Message(
+                                role='assistant',
+                                content=self._try_convert_thinking(stream_output_pending_chunk),
                             )
                             batch_pending_index = 0
                 elif chunk['event'] == 'message_end':
                     yield llm_entities.Message(
                         role='assistant',
-                        content=self._try_convert_thinking(basic_mode_pending_chunk),
+                        content=self._try_convert_thinking(stream_output_pending_chunk),
                     )
-                    basic_mode_pending_chunk = ''
+                    stream_output_pending_chunk = ''
 
         if chunk is None:
             raise errors.DifyAPIError('Dify API 没有返回任何响应，请检查网络连接和API配置')

--- a/pkg/provider/runners/difysvapi.py
+++ b/pkg/provider/runners/difysvapi.py
@@ -108,6 +108,10 @@ class DifyServiceAPIRunner(runner.RequestRunner):
         mode = 'basic'  # 标记是基础编排还是工作流编排
 
         basic_mode_pending_chunk = ''
+        
+        batch_pending_max_size = self.pipeline_config['ai']['dify-service-api'].get('output-batch-size', 0) # 积累一定量的消息更新消息一次
+        
+        batch_pending_index = 0
 
         inputs = {}
 
@@ -124,6 +128,13 @@ class DifyServiceAPIRunner(runner.RequestRunner):
             timeout=120,
         ):
             self.ap.logger.debug('dify-chat-chunk: ' + str(chunk))
+            
+            # 查询异常情况
+            if chunk['event'] == 'error':
+                yield llm_entities.Message(
+                        role="assistant",
+                        content=f"查询异常: [{chunk['code']}]. {chunk['message']}.\n请重试，如果还报错，请用 <font color='red'>**!reset**</font> 命令重置对话再尝试。",
+                    )
 
             if chunk['event'] == 'workflow_started':
                 mode = 'workflow'
@@ -138,6 +149,15 @@ class DifyServiceAPIRunner(runner.RequestRunner):
             elif mode == 'basic':
                 if chunk['event'] == 'message':
                     basic_mode_pending_chunk += chunk['answer']
+                    if self.pipeline_config['ai']['dify-service-api'].get('enable-streaming', False): 
+                        # 消息数超过量就输出，从而达到streaming的效果
+                        batch_pending_index += 1
+                        if batch_pending_index >= batch_pending_max_size:
+                            yield llm_entities.Message(
+                                role="assistant",
+                                content=self._try_convert_thinking(basic_mode_pending_chunk),
+                            )
+                            batch_pending_index = 0
                 elif chunk['event'] == 'message_end':
                     yield llm_entities.Message(
                         role='assistant',

--- a/templates/metadata/pipeline/ai.yaml
+++ b/templates/metadata/pipeline/ai.yaml
@@ -124,6 +124,21 @@ stages:
             label:
               en_US: Remove
               zh_Hans: 移除
+      - name: enable-streaming
+        label:
+          en_US: enable streaming mode
+          zh_Hans: 开启流式输出
+        type: boolean
+        required: true
+        default: false
+      - name: output-batch-size
+        label:
+          en_US: output batch size
+          zh_Hans: 输出批次大小(积累多少条消息后一起输出)
+        type: integer
+        required: true
+        default: 10
+
   - name: dashscope-app-api
     label:
       en_US: Aliyun Dashscope App API

--- a/web/src/app/home/bots/components/bot-form/BotForm.tsx
+++ b/web/src/app/home/bots/components/bot-form/BotForm.tsx
@@ -202,6 +202,7 @@ export default function BotForm({
               default: item.default,
               id: UUID.generate(),
               label: item.label,
+              description: item.description,
               name: item.name,
               required: item.required,
               type: parseDynamicFormItemType(item.type),

--- a/web/src/app/infra/entities/api/index.ts
+++ b/web/src/app/infra/entities/api/index.ts
@@ -95,6 +95,7 @@ export interface Adapter {
 export interface AdapterSpecConfig {
   default: string | number | boolean | Array<unknown>;
   label: I18nText;
+  description?: I18nText;
   name: string;
   required: boolean;
   type: string;


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 
feature: #1364  #1302 #1283 

效果图：
![image](https://github.com/user-attachments/assets/75e5c662-47fd-4133-870d-f3d4150fa528)

### 实现方式：
1. 使用飞书卡片消息来实现消息的更新(普通消息更新有次数限制)
2. 飞书发消息后，先生成一个卡片消息，内容为"思考中"。
![image](https://github.com/user-attachments/assets/a2f9cf76-b374-4757-9de6-a68c595b8129)
3. 调用dify获得数据后，积累一定消息数(如10条)就更新一次卡片，从而达到实现流式输出的效果。

### 使用要求：
1. 在飞书开发者后台创建一个卡片(可以使用飞书卡片搭建工具)
![image](https://github.com/user-attachments/assets/9747e258-87c7-4a65-8dfc-cb159d0b51d3)

2. 机器人设置打开卡片功能，并设置卡片模板ID
![image](https://github.com/user-attachments/assets/648dcac6-dc32-4914-9ecc-f04c48828a7e)

3. dify流水线要打开流式输出开关
![image](https://github.com/user-attachments/assets/8cea2b1b-9a2c-4971-b06d-25592d3b4640)

### 其他：
- 此次也修复了lark config变化后，旧连接不清理，导致连接很多，消息监听有可能随机到其中一个老连接上的问题。


## 检查清单

### PR 作者完成

*请在方括号间写`x`以打勾

- [x] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？
- [ ] 与项目所有者沟通过了吗？
- [x] 我确定已自行测试所作的更改，确保功能符合预期。

### 项目所有者完成

- [ ] 相关 issues 链接了吗？
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗
- [ ] 文档编写了吗？