### PR TITLE
解决mcp func没有被带给模型API，解决 issues: 1430

### DIFF
--- a/pkg/pipeline/preproc/preproc.py
+++ b/pkg/pipeline/preproc/preproc.py
@@ -59,7 +59,7 @@ class PreProcessor(stage.PipelineStage):
 
         if selected_runner == 'local-agent':
             query.use_funcs = (
-                conversation.use_funcs if query.use_llm_model.model_entity.abilities.__contains__('tool_call') else None
+                conversation.use_funcs if any(ability in query.use_llm_model.model_entity.abilities for ability in ['tool_call', 'func_call']) else None
             )
 
         query.variables = {


### PR DESCRIPTION
## 概述 / Overview

> 解决mcp func没有被带给模型API，解决   [issues: 1430](https://github.com/RockChinQ/LangBot/issues/1430)

## 检查清单 / Checklist

问题原因在于web后台模型能力选择中的函数调用在代码中称为 func_call，而在检查是否勾选了函数调用的代码中检查了 tool_call。

解决方案：同时检查模型能力中是否存在 tool_call 和 func_call。

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)?
- [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?