### PR TITLE
feat:add onebotv11 face send and accept but some face no name.

### DIFF
--- a/pkg/platform/sources/aiocqhttp.py
+++ b/pkg/platform/sources/aiocqhttp.py
@@ -202,13 +202,13 @@ class AiocqhttpMessageConverter(adapter.MessageConverter):
                 face_name = msg.data['raw']['faceText']
                 if not face_name:
                     face_name = get_face_name(face_id)
-                yiri_msg_list.append(platform_message.Face(face_id=face_id,face_name=face_name.replace('/','')))
+                yiri_msg_list.append(platform_message.Face(face_id=int(face_id),face_name=face_name.replace('/','')))
             elif msg.type == 'rps':
                 face_id = msg.data['result']
-                yiri_msg_list.append(platform_message.Face(face_type="rps",face_id=face_id,face_name='猜拳'))
+                yiri_msg_list.append(platform_message.Face(face_type="rps",face_id=int(face_id),face_name='猜拳'))
             elif msg.type == 'dice':
                 face_id = msg.data['result']
-                yiri_msg_list.append(platform_message.Face(face_type='dice',face_id=face_id,face_name='骰子'))
+                yiri_msg_list.append(platform_message.Face(face_type='dice',face_id=int(face_id),face_name='骰子'))
 
 
 

--- a/pkg/platform/sources/aiocqhttp.py
+++ b/pkg/platform/sources/aiocqhttp.py
@@ -81,6 +81,42 @@ class AiocqhttpMessageConverter(adapter.MessageConverter):
     async def target2yiri(message: str, message_id: int = -1,bot=None):
         message = aiocqhttp.Message(message)
 
+        def get_face_name(face_id):
+            face_code_dict = {
+                "2": '好色',
+                "4": "得意", "5": "流泪", "8": "睡", "9": "大哭", "10": "尴尬", "12": "调皮", "14": "微笑", "16": "酷",
+                "21": "可爱",
+                "23": "傲慢", "24": "饥饿", "25": "困", "26": "惊恐", "27": "流汗", "28": "憨笑", "29": "悠闲",
+                "30": "奋斗",
+                "32": "疑问", "33": "嘘", "34": "晕", "38": "敲打", "39": "再见", "41": "发抖", "42": "爱情",
+                "43": "跳跳",
+                "49": "拥抱", "53": "蛋糕", "60": "咖啡", "63": "玫瑰", "66": "爱心", "74": "太阳", "75": "月亮",
+                "76": "赞",
+                "78": "握手", "79": "胜利", "85": "飞吻", "89": "西瓜", "96": "冷汗", "97": "擦汗", "98": "抠鼻",
+                "99": "鼓掌",
+                "100": "糗大了", "101": "坏笑", "102": "左哼哼", "103": "右哼哼", "104": "哈欠", "106": "委屈",
+                "109": "左亲亲",
+                "111": "可怜", "116": "示爱", "118": "抱拳", "120": "拳头", "122": "爱你", "123": "NO", "124": "OK",
+                "125": "转圈",
+                "129": "挥手", "144": "喝彩", "147": "棒棒糖", "171": "茶", "173": "泪奔", "174": "无奈", "175": "卖萌",
+                "176": "小纠结", "179": "doge", "180": "惊喜", "181": "骚扰", "182": "笑哭", "183": "我最美",
+                "201": "点赞",
+                "203": "托脸", "212": "托腮", "214": "啵啵", "219": "蹭一蹭", "222": "抱抱", "227": "拍手",
+                "232": "佛系",
+                "240": "喷脸", "243": "甩头", "246": "加油抱抱", "262": "脑阔疼", "264": "捂脸", "265": "辣眼睛",
+                "266": "哦哟",
+                "267": "头秃", "268": "问号脸", "269": "暗中观察", "270": "emm", "271": "吃瓜", "272": "呵呵哒",
+                "273": "我酸了",
+                "277": "汪汪", "278": "汗", "281": "无眼笑", "282": "敬礼", "284": "面无表情", "285": "摸鱼",
+                "287": "哦",
+                "289": "睁眼", "290": "敲开心", "293": "摸锦鲤", "294": "期待", "297": "拜谢", "298": "元宝",
+                "299": "牛啊",
+                "305": "右亲亲", "306": "牛气冲天", "307": "喵喵", "314": "仔细分析", "315": "加油", "318": "崇拜",
+                "319": "比心",
+                "320": "庆祝", "322": "拒绝", "324": "吃糖", "326": "生气"
+            }
+            return face_code_dict.get(face_id,'')
+
         async def process_message_data(msg_data, reply_list):
             if msg_data["type"] == "image":
                 image_base64, image_format = await image.qq_image_url_to_base64(msg_data["data"]['url'])
@@ -157,7 +193,7 @@ class AiocqhttpMessageConverter(adapter.MessageConverter):
                 face_id = msg.data['id']
                 face_name = msg.data['raw']['faceText']
                 if not face_name:
-                    face_name = ''
+                    face_name = get_face_name(face_id)
                 yiri_msg_list.append(platform_message.Face(face_id=face_id,face_name=face_name.replace('/','')))
             elif msg.type == 'rps':
                 face_id = msg.data['result']
@@ -177,6 +213,8 @@ class AiocqhttpMessageConverter(adapter.MessageConverter):
         chain = platform_message.MessageChain(yiri_msg_list)
 
         return chain
+
+
 
 
 

--- a/pkg/platform/sources/aiocqhttp.py
+++ b/pkg/platform/sources/aiocqhttp.py
@@ -79,6 +79,7 @@ class AiocqhttpMessageConverter(adapter.MessageConverter):
 
     @staticmethod
     async def target2yiri(message: str, message_id: int = -1,bot=None):
+        print(message)
         message = aiocqhttp.Message(message)
 
         def get_face_name(face_id):
@@ -160,8 +161,15 @@ class AiocqhttpMessageConverter(adapter.MessageConverter):
             elif msg.type == 'text':
                 yiri_msg_list.append(platform_message.Plain(text=msg.data['text']))
             elif msg.type == 'image':
-                image_base64, image_format = await image.qq_image_url_to_base64(msg.data['url'])
-                yiri_msg_list.append(platform_message.Image(base64=f'data:image/{image_format};base64,{image_base64}'))
+                emoji_id = msg.data.get("emoji_package_id", None)
+                if emoji_id:
+                    face_id = emoji_id
+                    face_name = msg.data.get("summary", '')
+                    image_msg = platform_message.Face(face_id=face_id, face_name=face_name)
+                else:
+                    image_base64, image_format = await image.qq_image_url_to_base64(msg.data['url'])
+                    image_msg = platform_message.Image(base64=f'data:image/{image_format};base64,{image_base64}')
+                yiri_msg_list.append(image_msg)
             elif msg.type == 'forward':
                 # 暂时不太合理
                 # msg_datas = await bot.get_msg(message_id=message_id)

--- a/pkg/platform/types/message.py
+++ b/pkg/platform/types/message.py
@@ -813,7 +813,11 @@ class File(MessageComponent):
         return f'[文件]{self.name}'
 
 class Face(MessageComponent):
-    """系统表情"""
+    """系统表情
+    此处将超级表情骰子/划拳，一同归类于face
+    当face_type为rps(划拳)时 face_id 对应的是手势
+    当face_type为dice(骰子)时 face_id 对应的是点数
+    """
     type: str = 'Face'
     """表情类型"""
     face_type: str = 'face'

--- a/pkg/platform/types/message.py
+++ b/pkg/platform/types/message.py
@@ -804,7 +804,7 @@ class File(MessageComponent):
     """文件识别 ID。"""
     name: str
     """文件名称。"""
-    size: int = ''
+    size: int = 0
     """文件大小。"""
     url: str
     """文件路径"""
@@ -812,6 +812,32 @@ class File(MessageComponent):
     def __str__(self):
         return f'[文件]{self.name}'
 
+class Face(MessageComponent):
+    """系统表情"""
+    type: str = 'Face'
+    """表情类型"""
+    face_type: str = 'face'
+    """表情id"""
+    face_id: int = 0
+    """表情名"""
+    face_name: str = ''
+
+    def __str__(self):
+        if self.face_type == 'face':
+            return f'[表情]{self.face_name}'
+        elif self.face_type == 'dice':
+            return f'[表情]{self.face_id}点的{self.face_name}'
+        elif self.face_type == 'rps':
+            return f'[表情]{self.face_name}({self.rps_data(self.face_id)})'
+
+
+    def rps_data(self,face_id):
+        rps_dict ={
+            1 : "布",
+            2 : "剪刀",
+            3 : "石头",
+        }
+        return rps_dict[face_id]
 
 # ================ 个人微信专用组件 ================
 
@@ -935,7 +961,7 @@ class WeChatFile(MessageComponent):
     """文件识别 ID。"""
     file_name: str = ''
     """文件名称。"""
-    file_size: int = ''
+    file_size: int = 0
     """文件大小。"""
     file_path: str = ''
     """文件地址"""


### PR DESCRIPTION
## 概述 / Overview

增加了onbotv11适配器的接受和发送表情的功能，新增了face消息类，将超级表情骰子和划拳一同归为face,但是有部分古老表情在消息中拿不到face_name,如需要需要需插件或者后续将表情表适配？

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/RockChinQ/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?